### PR TITLE
fix: Cannot read property 'length' of undefined

### DIFF
--- a/src/simplifyTitle.ts
+++ b/src/simplifyTitle.ts
@@ -31,7 +31,7 @@ export function simplifyTitle(title: string): string {
 const requestInfoRegex = /\[.+?\]/i;
 
 export function releaseTitleCleaner(title: string): string | null {
-  if (title.length === 0 || title === '(') {
+  if (!title || title.length === 0 || title === '(') {
     return null;
   }
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'length' of undefined
    at Object.releaseTitleCleaner (node_modules/@ctrl/video-filename-parser/src/simplifyTitle.ts:34:13)
    at Object.parseTitleAndYear (node_modules/@ctrl/video-filename-parser/src/title.ts:36:22)
    at Object.parseGroup (node_modules/@ctrl/video-filename-parser/src/group.ts:11:33)
    at Object.filenameParse (node_modules/@ctrl/video-filename-parser/src/filenameParse.ts:88:17)
```