### PR TITLE
feat(season): Split season parser by match shape

### DIFF
--- a/src/season.ts
+++ b/src/season.ts
@@ -1,210 +1,13 @@
+import {
+  completeRange,
+  normalizeSixDigitAirDate,
+  parseGenericMatchCollection,
+  type ParsedMatchCollection,
+} from './season/common.js';
+import { rejectedPatterns, seasonPatterns } from './season/patterns.js';
 import { simplifyTitle } from './simplifyTitle.js';
 
-const reportTitleExp = [
-  // Daily episodes without title (2018-10-12, 20181012) (Strict pattern to avoid false matches)
-  /^(?<airyear>19[6-9]\d|20\d\d)(?<sep>[-_]?)(?<airmonth>0\d|1[0-2])\k<sep>(?<airday>[0-2]\d|3[01])(?!\d)/i,
-  // Multi-Part episodes without a title (S01E05.S01E06)
-  /^(?:\W*S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[ex]){1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}/i,
-
-  // Multi-episode with single episode numbers (S6.E1-E2, S6.E1E2, S6E1E2, etc)
-  /^(?<title>.+?)[-_. ]S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:[E-_. ]?[ex]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+(?:[-_. ]?[ex]?(?<episode1>(?<!\d+)\d{1,2}(?!\d+)))+/i,
-
-  // Multi-Episode with a title (S01E05E06, S01E05-06, S01E05 E06, etc) and trailing info in slashes
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode1>\d{2,3}(?!\d+)))+).+?(?:\[.+?\])(?!\\)/i,
-
-  // Episodes without a title, Multi (S01E04E05, 1x04x05, etc)
-  /(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_]|[ex]){1,2}(?<episode>\d{2,3}(?!\d+))){2,})/i,
-  // Episodes without a title, Single (S01E05, 1x05)
-  /^(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_ ]?[ex])(?<episode>\d{2,3}(?!\d+))))/i,
-  // Anime - [SubGroup] Title Episode Absolute Episode Number ([SubGroup] Series Title Episode 01)
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
-  // Anime - [SubGroup] Title Absolute Episode Number + Season+Episode
-  /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?))+(?:_|-|\s|\.)+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+).*?(?<hash>[([]\w{8}[)\]])?(?:$|\.)/i,
-  // Anime - [SubGroup] Title Season+Episode + Absolute Episode Number
-  /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:(?:_|-|\s|\.)+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+.*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-  // Anime - [SubGroup] Title Season+Episode
-  /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:\s|\.).*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-  // Anime - [SubGroup] Title with trailing number Absolute Episode Number
-  /^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?\d+?)[-_. ]+(?:[-_. ]?(?<absoluteepisode>\d{3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
-  // Anime - [SubGroup] Title - Absolute Episode Number
-  /^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:[. ]-[. ](?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-])))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
-
-  // Anime - [SubGroup] Title Absolute Episode Number
-  /^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+\(?(?:[-_. ]?#?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+\)?(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
-  // Multi-episode Repeated (S01E05 - S01E06, 1x05 - 1x06, etc)
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[ex]|[-_. ]e){1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}/i,
-
-  // Single episodes with a title (S01E05, 1x05, etc)
-  // modified from sonarr to not match "trailing info in slashes"
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>(?!265|264)\d{2,3}(?!\d+|(?:[ex]|\W[ex]|_|-){1,2})))/i,
-
-  // Anime - Title Season EpisodeNumber + Absolute Episode Number [SubGroup]
-  /^(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))).+?(?:[-_. ]?(?<absoluteepisode>(?<!\d+)\d{3}(\.\d{1,2})?(?!\d+)))+.+?\[(?<subgroup>.+?)\](?:$|\.mkv)/i,
-
-  // Anime - Title Absolute Episode Number [SubGroup] [Hash]? (Series Title Episode 99-100 [RlsGroup] [ABCD1234])
-  /^(?<title>.+?)[-_. ]Episode(?:[-_. ]+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-  // Anime - Title Absolute Episode Number [SubGroup] [Hash]
-  /^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{3}(\.\d{1,2})(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-
-  // Anime - Title Absolute Episode Number [Hash]
-  /^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?[-_. ]+.*?(?<hash>\[\w{8}\])(?:$|\.)/i,
-
-  // Episodes with airdate AND season/episode number, capture season/epsiode only
-  /^(?<title>.+?)?\W*(?<airdate>\d{4}\W+[0-1][0-9]\W+[0-3][0-9])(?!\W+[0-3][0-9])[-_. ](?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))/i,
-
-  // Episodes with airdate AND season/episode number
-  /^(?<title>.+?)?\W*(?<airyear>\d{4})\W+(?<airmonth>[0-1][0-9])\W+(?<airday>[0-3][0-9])(?!\W+[0-3][0-9]).+?(?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))/i,
-
-  // Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
-  // /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode1>\d{2,3}(?!\d+)))*)\W?(?!\\)/i,
-
-  // Episodes with a title, 4 digit season number, Single episodes (S2016E05, etc) & Multi-episode (S2016E05E06, S2016E05-06, S2016E05 E06, etc)
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:e|\We|_){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|e|\We|_){1,2}(?<episode1>\d{2,3}(?!\d+)))*)\W?(?!\\)/i,
-
-  // Episodes with a title, 4 digit season number, Single episodes (2016x05, etc) & Multi-episode (2016x05x06, 2016x05-06, 2016x05 x06, etc)
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:x|\Wx){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|x|\Wx|_){1,2}(?<episode1>\d{2,3}(?!\d+)))*)\W?(?!\\)/i,
-
-  // Multi-season pack
-  /^(?<title>.+?)[-_. ]+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))\W?-\W?S?(?<season1>(?<!\d+)(?:\d{1,2})(?!\d+))/i,
-
-  // Partial season pack
-  /^(?<title>.+?)(?:\W+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))\W+(?:(?:Part\W?|(?<!\d+\W+)e)(?<seasonpart>\d{1,2}(?!\d+)))+)/i,
-
-  // Mini-Series with year in title, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
-  /^(?<title>.+?\d{4})(?:\W+(?:(?:Part\W?|e)(?<episode>\d{1,2}(?!\d+)))+)/i,
-  // Mini-Series, treated as season 1, multi episodes are labelled as E1-E2
-  /^(?<title>.+?)(?:[-._ ][e])(?<episode>\d{2,3}(?!\d+))(?:(?:-?[e])(?<episode1>\d{2,3}(?!\d+)))+/i,
-
-  // Mini-Series, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
-  /^(?<title>.+?)(?:\W+(?:(?:Part\W?|(?<!\d+\W+)e)(?<episode>\d{1,2}(?!\d+)))+)/i,
-
-  // Mini-Series, treated as season 1, episodes are labelled as Part One/Two/Three/...Nine, Part.One, Part_One
-  /^(?<title>.+?)(?:\W+(?:Part[-._ ](?<episode>One|Two|Three|Four|Five|Six|Seven|Eight|Nine)(>[-._ ])))/i,
-
-  // Mini-Series, treated as season 1, episodes are labelled as XofY
-  /^(?<title>.+?)(?:\W+(?:(?<episode>(?<!\d+)\d{1,2}(?!\d+))of\d+)+)/i,
-
-  // Supports Season 01 Episode 03
-  /(?:.*(?:""|^))(?<title>.*?)(?:[-_\W](?<![()[]))+(?:\W?Season\W?)(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)+(?:Episode\W)(?:[-_. ]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+/i,
-
-  // Multi-episode with episodes in square brackets (Series Title [S01E11E12] or Series Title [S01E11-12])
-  /(?:.*(?:^))(?<title>.*?)[-._ ]+\[S(?<season>(?<!\d+)\d{2}(?!\d+))(?:[E-]{1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))+\]/i,
-
-  // Multi-episode release with no space between series title and season (S01E11E12)
-  /(?:.*(?:^))(?<title>.*?)S(?<season>(?<!\d+)\d{2}(?!\d+))(?:E(?<episode>(?<!\d+)\d{2}(?!\d+)))+/i,
-
-  // Single episode season or episode S1E1 or S1-E1 or S1.Ep1 or S01.Ep.01
-  /(?:.*(?:""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)?Ep?[ ._]?(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
-
-  // 3 digit season S010E05
-  /(?:.*(?:""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{3}(?!\d+))(?:\W|_)?E(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
-
-  // 5 digit episode number with a title
-  /^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))/i,
-
-  // 5 digit multi-episode with a title
-  /^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:[-_. ]{1,3}ep){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))+/i,
-
-  // Separated season and episode numbers S01 - E01
-  /^(?<title>.+?)(?:_|-|\s|\.)+S(?<season>\d{2}(?!\d+))(\W-\W)E(?<episode>(?<!\d+)\d{2}(?!\d+))(?!\\)/i,
-
-  // Anime - Title with season number - Absolute Episode Number (Title S01 - EP14)
-  /^(?<title>.+?S\d{1,2})[-_. ]{3,}(?:EP)?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))/i,
-
-  // Anime - French titles with single episode numbers, with or without leading sub group ([RlsGroup] Title - Episode 1)
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)[-_. ]+?(?:Episode[-_. ]+?)(?<absoluteepisode>\d{1}(\.\d{1,2})?(?!\d+))/i,
-
-  // Season only releases
-  /^(?<title>.+?)\W(?:S|Season)\W?(?<season>\d{1,2}(?!\d+))(\W+|_|$)(?<extras>EXTRAS|SUBPACK)?(?!\\)/i,
-
-  // 4 digit season only releases
-  /^(?<title>.+?)\W(?:S|Season)\W?(?<season>\d{4}(?!\d+))(\W+|_|$)(?<extras>EXTRAS|SUBPACK)?(?!\\)/i,
-
-  // Episodes with a title and season/episode in square brackets
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+\[S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+|i|p)))+\])\W?(?!\\)/i,
-
-  // Supports 103/113 naming
-  /^(?<title>.+?)?(?:(?:[_.](?<![()[!]))+(?<season>(?<!\d+)[1-9])(?<episode>[1-9][0-9]|[0][1-9])(?![a-z]|\d+))+(?:[_.]|$)/i,
-
-  // 4 digit episode number
-  // Episodes without a title, Single (S01E05, 1x05) AND Multi (S01E04E05, 1x04x05, etc)
-  /^(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)(\W+|_|$)(?!\\)/i,
-
-  // 4 digit episode number
-  // Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
-  /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)\W?(?!\\)/i,
-
-  // Episodes with airdate (2018.04.28)
-  /^(?<title>.+?)?\W*(?<airyear>\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])(?![-_. ]+[0-3][0-9])/i,
-
-  // Episodes with airdate (04.28.2018)
-  /^(?<title>.+?)?\W*(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])[-_. ]+(?<airyear>\d{4})(?!\d+)/i,
-
-  // Supports 1103/1113 naming
-  /^(?<title>.+?)?(?:(?:[-_\W](?<![()[!]))*(?<season>(?<!\d+|\(|\[|e|x)\d{2})(?<episode>(?<!e|x)\d{2}(?!p|i|\d+|\)|\]|\W\d+|\W(?:e|ep|x)\d+)))+(\W+|_|$)(?!\\)/i,
-
-  // Episodes with single digit episode number (S01E1, S01E5E6, etc)
-  /^(?<title>.*?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]){1,2}(?<episode>\d{1}))+)+(\W+|_|$)(?!\\)/i,
-
-  // iTunes Season 1\05 Title (Quality).ext
-  /^(?:Season(?:_|-|\s|\.)(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:_|-|\s|\.)(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
-
-  // iTunes 1-05 Title (Quality).ext
-  /^(?:(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:-(?<episode>\d{2,3}(?!\d+))))/i,
-
-  // Anime Range - Title Absolute Episode Number (ep01-12)
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:_|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,3}(\.\d{1,2})?)-(?<absoluteepisode1>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-)).*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-
-  // Anime - Title Absolute Episode Number (e66)
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:_|-|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,4}(\.\d{1,2})?))+.*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
-
-  // Anime - Title Episode Absolute Episode Number (Series Title Episode 01)
-  /^(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
-
-  // Anime Range - Title Absolute Episode Number (1 or 2 digit absolute episode numbers in a range, 1-10)
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)[_. ]+(?<absoluteepisode>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+))-(?<absoluteepisode1>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-))(?:_|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
-
-  // Anime - Title Absolute Episode Number
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
-
-  // Anime - Title {Absolute Episode Number}
-  /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
-
-  // Extant, terrible multi-episode naming (extant.10708.hdtv-lol.mp4)
-  /^(?<title>.+?)[-_. ](?<season>[0]?\d?)(?:(?<episode>\d{2}){2}(?!\d+))[-_. ]/i,
-];
-
-const rejectedRegexes = [
-  // Generic match for md5 and mixed-case hashes.
-  /^[0-9a-zA-Z]{32}/i,
-
-  // Generic match for shorter lower-case hashes.
-  /^[a-z0-9]{24}$/i,
-
-  // Format seen on some NZBGeek releases
-  // Be very strict with these coz they are very close to the valid 101 ep numbering.
-  /"^[A-Z]{11}\d{3}$/i,
-  /"^[a-z]{12}\d{3}$/i,
-
-  // Backup filename (Unknown origins)
-  /^Backup_\d{5,}S\d{2}-\d{2}$/i,
-
-  // 123 - Started appearing December 2014
-  /^123$"/,
-
-  // abc - Started appearing January 2015
-  /^abc$"/i,
-
-  // b00bs - Started appearing January 2015
-  /^b00bs$"/i,
-
-  // 170424_26 - Started appearing August 2018
-  /^\d{6}_\d{2}$"/,
-];
-
-const requestInfoExp = /^(?:\[.+?\])+/;
-const sixDigitAirDateMatchExp =
-  /"(?<=[_.-])(?<airdate>(?<!\d)(?<airyear>[1-9]\d{1})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9]))(?=[_.-])/i;
+export { completeRange, type ParsedMatchCollection };
 
 export interface Season {
   releaseTitle: string;
@@ -233,56 +36,34 @@ export function parseSeason(title: string): Season | null {
     return null;
   }
 
-  let simpleTitle = simplifyTitle(title);
+  const simpleTitle = normalizeSixDigitAirDate(title, simplifyTitle(title));
 
-  // parse daily episodes with mmddyy eg `At.Midnight.140722.720p.HDTV.x264-YesTV`
-  const sixDigitAirDateMatch = sixDigitAirDateMatchExp.exec(title);
-  if (sixDigitAirDateMatch?.groups) {
-    const airYear = sixDigitAirDateMatch.groups.airyear ?? '';
-    const airMonth = sixDigitAirDateMatch.groups.airmonth ?? '';
-    const airDay = sixDigitAirDateMatch.groups.airday ?? '';
-    if (airMonth !== '00' || airDay !== '00') {
-      const fixedDate = `20${airYear}.${airMonth}.${airDay}`;
-
-      simpleTitle = simpleTitle.replace(sixDigitAirDateMatch.groups.airdate ?? '', fixedDate);
+  for (const pattern of seasonPatterns) {
+    const match = pattern.regex.exec(simpleTitle);
+    if (!match?.groups) {
+      continue;
     }
-  }
 
-  for (const exp of reportTitleExp) {
-    const match = exp.exec(simpleTitle);
-    if (match?.groups) {
-      const result = parseMatchCollection(match, simpleTitle);
-
-      if (result === null) {
-        continue;
-      }
-
-      if (result.fullSeason && result.releaseTokens && /Special/i.test(result.releaseTokens)) {
-        result.fullSeason = false;
-        result.isSpecial = true;
-      }
-
-      return {
-        releaseTitle: title,
-        seriesTitle: result.seriesName,
-        seasons: result.seasonNumbers ?? [],
-        episodeNumbers: result.episodeNumbers ?? [],
-        airDate: result.airDate ?? null,
-        fullSeason: result.fullSeason ?? false,
-        isPartialSeason: result.isPartialSeason ?? false,
-        isMultiSeason: result.isMultiSeason ?? false,
-        isSeasonExtra: result.isSeasonExtra ?? false,
-        isSpecial: result.isSpecial ?? false,
-        seasonPart: result.seasonPart ?? 0,
-      };
+    const result = pattern.parse(match, simpleTitle);
+    if (result === null) {
+      continue;
     }
+
+    return toSeason(title, result);
   }
 
   return null;
 }
 
+export function parseMatchCollection(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parseGenericMatchCollection(match, simpleTitle);
+}
+
 function preValidation(title: string): boolean {
-  for (const exp of rejectedRegexes) {
+  for (const exp of rejectedPatterns) {
     const match = exp.exec(title);
     if (match !== null) {
       return false;
@@ -292,195 +73,23 @@ function preValidation(title: string): boolean {
   return true;
 }
 
-export const completeRange = (arr: number[]): number[] => {
-  const uniqArr = [...new Set(arr)];
-
-  const first = Number(uniqArr[0]);
-  const last = Number(uniqArr[uniqArr.length - 1]);
-
-  if (first > last) {
-    return arr;
+function toSeason(title: string, result: ParsedMatchCollection): Season {
+  if (result.fullSeason && result.releaseTokens && /Special/i.test(result.releaseTokens)) {
+    result.fullSeason = false;
+    result.isSpecial = true;
   }
 
-  const count = last - first + 1;
-  return [...Array.from({ length: count }).keys()].map(k => k + first);
-};
-
-const indexOfEnd = (str1: string, str2: string): number => {
-  const io = str1.indexOf(str2);
-  return io === -1 ? -1 : io + str2.length;
-};
-
-export interface ParsedMatchCollection {
-  seriesName: string;
-  seriesTitle?: string;
-  seasonNumbers?: number[];
-  isMultiSeason?: boolean;
-  episodeNumbers?: number[];
-  isSpecial?: boolean;
-  isSeasonExtra?: boolean;
-  seasonPart?: number;
-  isPartialSeason?: boolean;
-  fullSeason?: boolean;
-  airDate?: Date;
-  releaseTokens?: string;
-}
-
-export function parseMatchCollection(
-  match: RegExpExecArray,
-  simpleTitle: string,
-): ParsedMatchCollection | null {
-  const { groups } = match;
-  if (groups === undefined) {
-    throw new Error('No match');
-  }
-
-  const seriesName = (groups.title ?? '')
-    .replace(/\./g, ' ')
-    .replace(/_/g, ' ')
-    .replace(requestInfoExp, '')
-    .trim();
-
-  const result: ParsedMatchCollection = {
-    seriesName,
+  return {
+    releaseTitle: title,
+    seriesTitle: result.seriesName,
+    seasons: result.seasonNumbers ?? [],
+    episodeNumbers: result.episodeNumbers ?? [],
+    airDate: result.airDate ?? null,
+    fullSeason: result.fullSeason ?? false,
+    isPartialSeason: result.isPartialSeason ?? false,
+    isMultiSeason: result.isMultiSeason ?? false,
+    isSeasonExtra: result.isSeasonExtra ?? false,
+    isSpecial: result.isSpecial ?? false,
+    seasonPart: result.seasonPart ?? 0,
   };
-
-  let lastSeasonEpisodeStringIndex = indexOfEnd(simpleTitle, groups.title ?? '');
-
-  const airYear = Number.parseInt(groups.airyear ?? '', 10);
-  if (airYear < 1900 || Number.isNaN(airYear)) {
-    let seasons = [groups.season, groups.season1]
-      .filter(x => x !== undefined && x.length > 0)
-      .map(x => {
-        lastSeasonEpisodeStringIndex = Math.max(
-          indexOfEnd(simpleTitle, x ?? ''),
-          lastSeasonEpisodeStringIndex,
-        );
-        return Number(x);
-      });
-
-    if (seasons.length > 1) {
-      seasons = completeRange(seasons);
-    }
-
-    result.seasonNumbers = seasons;
-    if (seasons.length > 1) {
-      result.isMultiSeason = true;
-    }
-
-    const episodeCaptures = [groups.episode, groups.episode1].filter(x => x);
-    const absoluteEpisodeCaptures = [groups.absoluteepisode, groups.absoluteepisode1].filter(
-      x => x,
-    );
-
-    // handle 0 episode possibly indicating a full season release
-    if (episodeCaptures.length > 0) {
-      const first = Number(episodeCaptures[0]);
-      const last = Number(episodeCaptures[episodeCaptures.length - 1]);
-
-      if (first > last) {
-        return null;
-      }
-
-      const count = last - first + 1;
-      result.episodeNumbers = [...Array.from({ length: count }).keys()].map(k => k + first);
-    }
-
-    if (absoluteEpisodeCaptures.length > 0) {
-      const first = Number(absoluteEpisodeCaptures[0]);
-      const last = Number(absoluteEpisodeCaptures[episodeCaptures.length - 1]);
-
-      if (first % 1 !== 0 || last % 1 !== 0) {
-        if (absoluteEpisodeCaptures.length !== 1) {
-          return null;
-        }
-
-        // specialAbsoluteEpisodeNumbers in radarr
-        result.episodeNumbers = [first];
-        result.isSpecial = true;
-
-        lastSeasonEpisodeStringIndex = Math.max(
-          indexOfEnd(simpleTitle, absoluteEpisodeCaptures[0] ?? ''),
-          lastSeasonEpisodeStringIndex,
-        );
-      } else {
-        const count = last - first + 1;
-        // AbsoluteEpisodeNumbers in radarr
-        result.episodeNumbers = [...Array.from({ length: Math.floor(count) }).keys()].map(
-          k => k + Math.floor(first),
-        );
-
-        if (groups.special) {
-          result.isSpecial = true;
-        }
-      }
-    }
-
-    if (episodeCaptures.length === 0 && absoluteEpisodeCaptures.length === 0) {
-      // Check to see if this is an "Extras" or "SUBPACK" release, if it is, set
-      // IsSeasonExtra so they can be filtered out
-      if (groups.extras) {
-        result.isSeasonExtra = true;
-      }
-
-      // Partial season packs will have a seasonpart group so they can be differentiated
-      // from a full season/single episode release
-      const seasonPart = groups.seasonpart;
-      if (seasonPart) {
-        result.seasonPart = Number.parseInt(seasonPart, 10);
-        result.isPartialSeason = true;
-      } else {
-        result.fullSeason = true;
-      }
-    }
-
-    if (absoluteEpisodeCaptures.length > 0 && !result.episodeNumbers) {
-      result.seasonNumbers = [0];
-    }
-  } else {
-    let airMonth = Number.parseInt(groups.airmonth ?? '', 10);
-    let airDay = Number.parseInt(groups.airday ?? '', 10);
-
-    // Swap day and month if month is bigger than 12 (scene fail)
-    if (airMonth > 12) {
-      const tempDay = airDay;
-      airDay = airMonth;
-      airMonth = tempDay;
-    }
-
-    const airDate = new Date(airYear, airMonth - 1, airDay);
-
-    // dates in the future is most likely parser error
-    if (airDate.getTime() > Date.now()) {
-      throw new Error('Parsed date is in the future');
-    }
-
-    if (airDate.getTime() < new Date(1970, 1, 1).getTime()) {
-      throw new Error('Parsed date error');
-    }
-
-    lastSeasonEpisodeStringIndex = Math.max(
-      indexOfEnd(simpleTitle, groups.airyear ?? ''),
-      lastSeasonEpisodeStringIndex,
-    );
-    lastSeasonEpisodeStringIndex = Math.max(
-      indexOfEnd(simpleTitle, groups.airmonth ?? ''),
-      lastSeasonEpisodeStringIndex,
-    );
-    lastSeasonEpisodeStringIndex = Math.max(
-      indexOfEnd(simpleTitle, groups.airday ?? ''),
-      lastSeasonEpisodeStringIndex,
-    );
-    result.airDate = airDate;
-  }
-
-  if (lastSeasonEpisodeStringIndex === simpleTitle.length || lastSeasonEpisodeStringIndex === -1) {
-    result.releaseTokens = simpleTitle;
-  } else {
-    result.releaseTokens = simpleTitle.slice(lastSeasonEpisodeStringIndex);
-  }
-
-  result.seriesTitle = seriesName;
-
-  return result;
 }

--- a/src/season/common.ts
+++ b/src/season/common.ts
@@ -242,8 +242,8 @@ function createBaseResult(
   lastTokenIndex: number;
 } {
   const seriesName = (groups.title ?? '')
-    .replace(/\./g, ' ')
-    .replace(/_/g, ' ')
+    .replaceAll('.', ' ')
+    .replaceAll('_', ' ')
     .replace(requestInfoExp, '')
     .trim();
 

--- a/src/season/common.ts
+++ b/src/season/common.ts
@@ -1,0 +1,370 @@
+const requestInfoExp = /^(?:\[.+?\])+/;
+const sixDigitAirDateMatchExp =
+  /"(?<=[_.-])(?<airdate>(?<!\d)(?<airyear>[1-9]\d{1})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9]))(?=[_.-])/i;
+
+export interface ParsedMatchCollection {
+  seriesName: string;
+  seriesTitle?: string;
+  seasonNumbers?: number[];
+  isMultiSeason?: boolean;
+  episodeNumbers?: number[];
+  isSpecial?: boolean;
+  isSeasonExtra?: boolean;
+  seasonPart?: number;
+  isPartialSeason?: boolean;
+  fullSeason?: boolean;
+  airDate?: Date;
+  releaseTokens?: string;
+}
+
+type MatchGroups = NonNullable<RegExpExecArray['groups']>;
+
+export function completeRange(arr: number[]): number[] {
+  const uniqArr = [...new Set(arr)];
+
+  const first = Number(uniqArr[0]);
+  const last = Number(uniqArr[uniqArr.length - 1]);
+
+  if (first > last) {
+    return arr;
+  }
+
+  const count = last - first + 1;
+  return [...Array.from({ length: count }).keys()].map(k => k + first);
+}
+
+export function normalizeSixDigitAirDate(title: string, simpleTitle: string): string {
+  const sixDigitAirDateMatch = sixDigitAirDateMatchExp.exec(title);
+  if (!sixDigitAirDateMatch?.groups) {
+    return simpleTitle;
+  }
+
+  const airYear = sixDigitAirDateMatch.groups.airyear ?? '';
+  const airMonth = sixDigitAirDateMatch.groups.airmonth ?? '';
+  const airDay = sixDigitAirDateMatch.groups.airday ?? '';
+  if (airMonth === '00' && airDay === '00') {
+    return simpleTitle;
+  }
+
+  const fixedDate = `20${airYear}.${airMonth}.${airDay}`;
+  return simpleTitle.replace(sixDigitAirDateMatch.groups.airdate ?? '', fixedDate);
+}
+
+export function parseGenericMatchCollection(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { groups } = match;
+  if (groups === undefined) {
+    throw new Error('No match');
+  }
+
+  if (hasAirDate(groups)) {
+    return parseAirDateGroups(groups, simpleTitle);
+  }
+
+  const hasAbsoluteEpisode = Boolean(groups.absoluteepisode || groups.absoluteepisode1);
+  const hasSeasonPart = Boolean(groups.seasonpart);
+  const hasEpisode = Boolean(groups.episode || groups.episode1);
+
+  if (hasAbsoluteEpisode) {
+    return parseAbsoluteEpisodeGroups(groups, simpleTitle);
+  }
+
+  if (hasSeasonPart) {
+    return parsePartialSeasonGroups(groups, simpleTitle);
+  }
+
+  if (hasEpisode) {
+    return parseSeasonEpisodeGroups(groups, simpleTitle);
+  }
+
+  return parseSeasonPackGroups(groups, simpleTitle);
+}
+
+export function parseAirDateMatch(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parseAirDateGroups(requireGroups(match), simpleTitle);
+}
+
+export function parseSeasonEpisodeMatch(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parseSeasonEpisodeGroups(requireGroups(match), simpleTitle);
+}
+
+export function parseSeasonPackMatch(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parseSeasonPackGroups(requireGroups(match), simpleTitle);
+}
+
+export function parsePartialSeasonMatch(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parsePartialSeasonGroups(requireGroups(match), simpleTitle);
+}
+
+export function parseAbsoluteEpisodeMatch(
+  match: RegExpExecArray,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  return parseAbsoluteEpisodeGroups(requireGroups(match), simpleTitle);
+}
+
+function requireGroups(match: RegExpExecArray): MatchGroups {
+  const { groups } = match;
+  if (groups === undefined) {
+    throw new Error('No match');
+  }
+
+  return groups;
+}
+
+function hasAirDate(groups: MatchGroups): boolean {
+  const airYear = Number.parseInt(groups.airyear ?? '', 10);
+  return airYear >= 1900;
+}
+
+function parseAirDateGroups(
+  groups: MatchGroups,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { result } = createBaseResult(groups, simpleTitle);
+  let lastTokenIndex = indexOfEnd(simpleTitle, groups.title ?? '');
+  const airYear = Number.parseInt(groups.airyear ?? '', 10);
+  let airMonth = Number.parseInt(groups.airmonth ?? '', 10);
+  let airDay = Number.parseInt(groups.airday ?? '', 10);
+
+  if (airMonth > 12) {
+    const tempDay = airDay;
+    airDay = airMonth;
+    airMonth = tempDay;
+  }
+
+  const airDate = new Date(airYear, airMonth - 1, airDay);
+  if (airDate.getTime() > Date.now()) {
+    throw new Error('Parsed date is in the future');
+  }
+
+  if (airDate.getTime() < new Date(1970, 1, 1).getTime()) {
+    throw new Error('Parsed date error');
+  }
+
+  lastTokenIndex = Math.max(indexOfEnd(simpleTitle, groups.airyear ?? ''), lastTokenIndex);
+  lastTokenIndex = Math.max(indexOfEnd(simpleTitle, groups.airmonth ?? ''), lastTokenIndex);
+  lastTokenIndex = Math.max(indexOfEnd(simpleTitle, groups.airday ?? ''), lastTokenIndex);
+  result.airDate = airDate;
+
+  return finishResult(result, simpleTitle, lastTokenIndex);
+}
+
+function parseSeasonEpisodeGroups(
+  groups: MatchGroups,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
+  const nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
+  const episodeResult = applyEpisodeNumbers(result, groups);
+  if (episodeResult === null) {
+    return null;
+  }
+
+  return finishResult(result, simpleTitle, nextIndex);
+}
+
+function parseSeasonPackGroups(
+  groups: MatchGroups,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
+  const nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
+
+  if (groups.extras) {
+    result.isSeasonExtra = true;
+  }
+
+  result.fullSeason = true;
+  return finishResult(result, simpleTitle, nextIndex);
+}
+
+function parsePartialSeasonGroups(
+  groups: MatchGroups,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
+  const nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
+  const seasonPart = groups.seasonpart;
+
+  if (seasonPart) {
+    result.seasonPart = Number.parseInt(seasonPart, 10);
+    result.isPartialSeason = true;
+  } else {
+    result.fullSeason = true;
+  }
+
+  return finishResult(result, simpleTitle, nextIndex);
+}
+
+function parseAbsoluteEpisodeGroups(
+  groups: MatchGroups,
+  simpleTitle: string,
+): ParsedMatchCollection | null {
+  const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
+  let nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
+  const hasEpisodeCaptures = Boolean(groups.episode || groups.episode1);
+  const episodeResult = applyEpisodeNumbers(result, groups);
+  if (episodeResult === null) {
+    return null;
+  }
+
+  const absoluteResult = applyAbsoluteEpisodeNumbers(result, groups, {
+    preserveSingleAbsoluteAsSpecial: !hasEpisodeCaptures,
+  });
+  if (absoluteResult === null) {
+    return null;
+  }
+
+  if (absoluteResult.lastCapture) {
+    nextIndex = Math.max(indexOfEnd(simpleTitle, absoluteResult.lastCapture), nextIndex);
+  }
+
+  return finishResult(result, simpleTitle, nextIndex);
+}
+
+function createBaseResult(
+  groups: MatchGroups,
+  simpleTitle: string,
+): {
+  result: ParsedMatchCollection;
+  lastTokenIndex: number;
+} {
+  const seriesName = (groups.title ?? '')
+    .replace(/\./g, ' ')
+    .replace(/_/g, ' ')
+    .replace(requestInfoExp, '')
+    .trim();
+
+  return {
+    result: {
+      seriesName,
+    },
+    lastTokenIndex: indexOfEnd(simpleTitle, groups.title ?? ''),
+  };
+}
+
+function applySeasonNumbers(
+  result: ParsedMatchCollection,
+  groups: MatchGroups,
+  simpleTitle: string,
+  lastTokenIndex: number,
+): number {
+  let nextIndex = lastTokenIndex;
+  let seasons = [groups.season, groups.season1]
+    .filter(x => x !== undefined && x.length > 0)
+    .map(x => {
+      nextIndex = Math.max(indexOfEnd(simpleTitle, x ?? ''), nextIndex);
+      return Number(x);
+    });
+
+  if (seasons.length > 1) {
+    seasons = completeRange(seasons);
+  }
+
+  result.seasonNumbers = seasons;
+  if (seasons.length > 1) {
+    result.isMultiSeason = true;
+  }
+
+  return nextIndex;
+}
+
+function applyEpisodeNumbers(result: ParsedMatchCollection, groups: MatchGroups): null | undefined {
+  const episodeCaptures = [groups.episode, groups.episode1].filter(x => x);
+  if (episodeCaptures.length === 0) {
+    return undefined;
+  }
+
+  const first = Number(episodeCaptures[0]);
+  const last = Number(episodeCaptures[episodeCaptures.length - 1]);
+
+  if (first > last) {
+    return null;
+  }
+
+  const count = last - first + 1;
+  result.episodeNumbers = [...Array.from({ length: count }).keys()].map(k => k + first);
+  return undefined;
+}
+
+function applyAbsoluteEpisodeNumbers(
+  result: ParsedMatchCollection,
+  groups: MatchGroups,
+  options: { preserveSingleAbsoluteAsSpecial: boolean },
+): { lastCapture?: string } | null {
+  const absoluteEpisodeCaptures = [groups.absoluteepisode, groups.absoluteepisode1].filter(x => x);
+  if (absoluteEpisodeCaptures.length === 0) {
+    return {};
+  }
+
+  const first = Number(absoluteEpisodeCaptures[0]);
+  const lastCapture = absoluteEpisodeCaptures[absoluteEpisodeCaptures.length - 1] ?? '';
+  const last = Number(lastCapture);
+
+  if (first > last) {
+    return null;
+  }
+
+  if (first % 1 !== 0 || last % 1 !== 0) {
+    if (absoluteEpisodeCaptures.length !== 1) {
+      return null;
+    }
+
+    result.episodeNumbers = [first];
+    result.isSpecial = true;
+    return { lastCapture };
+  }
+
+  const count = last - first + 1;
+  result.episodeNumbers = [...Array.from({ length: Math.floor(count) }).keys()].map(
+    k => k + Math.floor(first),
+  );
+
+  if (
+    groups.special ||
+    (options.preserveSingleAbsoluteAsSpecial && absoluteEpisodeCaptures.length === 1)
+  ) {
+    result.isSpecial = true;
+  }
+
+  return { lastCapture };
+}
+
+function finishResult(
+  result: ParsedMatchCollection,
+  simpleTitle: string,
+  lastTokenIndex: number,
+): ParsedMatchCollection {
+  if (lastTokenIndex === simpleTitle.length || lastTokenIndex === -1) {
+    result.releaseTokens = simpleTitle;
+  } else {
+    result.releaseTokens = simpleTitle.slice(lastTokenIndex);
+  }
+
+  result.seriesTitle = result.seriesName;
+  return result;
+}
+
+function indexOfEnd(str1: string, str2: string): number {
+  if (str2.length === 0) {
+    return -1;
+  }
+
+  const io = str1.indexOf(str2);
+  return io === -1 ? -1 : io + str2.length;
+}

--- a/src/season/common.ts
+++ b/src/season/common.ts
@@ -217,15 +217,12 @@ function parseAbsoluteEpisodeGroups(
 ): ParsedMatchCollection | null {
   const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
   let nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
-  const hasEpisodeCaptures = Boolean(groups.episode || groups.episode1);
   const episodeResult = applyEpisodeNumbers(result, groups);
   if (episodeResult === null) {
     return null;
   }
 
-  const absoluteResult = applyAbsoluteEpisodeNumbers(result, groups, {
-    preserveSingleAbsoluteAsSpecial: !hasEpisodeCaptures,
-  });
+  const absoluteResult = applyAbsoluteEpisodeNumbers(result, groups);
   if (absoluteResult === null) {
     return null;
   }
@@ -305,7 +302,6 @@ function applyEpisodeNumbers(result: ParsedMatchCollection, groups: MatchGroups)
 function applyAbsoluteEpisodeNumbers(
   result: ParsedMatchCollection,
   groups: MatchGroups,
-  options: { preserveSingleAbsoluteAsSpecial: boolean },
 ): { lastCapture?: string } | null {
   const absoluteEpisodeCaptures = [groups.absoluteepisode, groups.absoluteepisode1].filter(x => x);
   if (absoluteEpisodeCaptures.length === 0) {
@@ -335,10 +331,7 @@ function applyAbsoluteEpisodeNumbers(
     k => k + Math.floor(first),
   );
 
-  if (
-    groups.special ||
-    (options.preserveSingleAbsoluteAsSpecial && absoluteEpisodeCaptures.length === 1)
-  ) {
+  if (groups.special) {
     result.isSpecial = true;
   }
 

--- a/src/season/patterns.ts
+++ b/src/season/patterns.ts
@@ -1,0 +1,295 @@
+import {
+  parseAbsoluteEpisodeMatch,
+  parseAirDateMatch,
+  parsePartialSeasonMatch,
+  parseSeasonEpisodeMatch,
+  parseSeasonPackMatch,
+  type ParsedMatchCollection,
+} from './common.js';
+
+export interface SeasonPattern {
+  name: string;
+  regex: RegExp;
+  parse: (match: RegExpExecArray, simpleTitle: string) => ParsedMatchCollection | null;
+}
+
+const airDate = (name: string, regex: RegExp): SeasonPattern => ({
+  name,
+  regex,
+  parse: parseAirDateMatch,
+});
+
+const seasonEpisode = (name: string, regex: RegExp): SeasonPattern => ({
+  name,
+  regex,
+  parse: parseSeasonEpisodeMatch,
+});
+
+const seasonPack = (name: string, regex: RegExp): SeasonPattern => ({
+  name,
+  regex,
+  parse: parseSeasonPackMatch,
+});
+
+const partialSeason = (name: string, regex: RegExp): SeasonPattern => ({
+  name,
+  regex,
+  parse: parsePartialSeasonMatch,
+});
+
+const absoluteEpisode = (name: string, regex: RegExp): SeasonPattern => ({
+  name,
+  regex,
+  parse: parseAbsoluteEpisodeMatch,
+});
+
+export const seasonPatterns: SeasonPattern[] = [
+  airDate(
+    'daily-airdate-no-title',
+    /^(?<airyear>19[6-9]\d|20\d\d)(?<sep>[-_]?)(?<airmonth>0\d|1[0-2])\k<sep>(?<airday>[0-2]\d|3[01])(?!\d)/i,
+  ),
+  seasonEpisode(
+    'multi-part-no-title',
+    /^(?:\W*S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[ex]){1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}/i,
+  ),
+  seasonEpisode(
+    'multi-episode-single-episode-numbers',
+    /^(?<title>.+?)[-_. ]S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:[E-_. ]?[ex]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+(?:[-_. ]?[ex]?(?<episode1>(?<!\d+)\d{1,2}(?!\d+)))+/i,
+  ),
+  seasonEpisode(
+    'multi-episode-with-title-and-trailing-info',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode1>\d{2,3}(?!\d+)))+).+?(?:\[.+?\])(?!\\)/i,
+  ),
+  seasonEpisode(
+    'multi-episode-no-title',
+    /(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_]|[ex]){1,2}(?<episode>\d{2,3}(?!\d+))){2,})/i,
+  ),
+  seasonEpisode(
+    'single-episode-no-title',
+    /^(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_ ]?[ex])(?<episode>\d{2,3}(?!\d+))))/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-title-episode-absolute',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-absolute-plus-season-episode',
+    /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?))+(?:_|-|\s|\.)+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+).*?(?<hash>[([]\w{8}[)\]])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-season-episode-plus-absolute',
+    /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:(?:_|-|\s|\.)+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+.*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  seasonEpisode(
+    'anime-subgroup-season-episode',
+    /^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:\s|\.).*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-title-with-trailing-number',
+    /^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?\d+?)[-_. ]+(?:[-_. ]?(?<absoluteepisode>\d{3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-title-dash-absolute',
+    /^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:[. ]-[. ](?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-])))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
+  ),
+  absoluteEpisode(
+    'anime-subgroup-title-absolute',
+    /^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+\(?(?:[-_. ]?#?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+\)?(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)/i,
+  ),
+  seasonEpisode(
+    'multi-episode-repeated',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[ex]|[-_. ]e){1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}/i,
+  ),
+  seasonEpisode(
+    'single-episode-with-title',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>(?!265|264)\d{2,3}(?!\d+|(?:[ex]|\W[ex]|_|-){1,2})))/i,
+  ),
+  absoluteEpisode(
+    'anime-title-season-episode-plus-absolute-subgroup',
+    /^(?<title>.+?)(?:[-_\W](?<![()[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))).+?(?:[-_. ]?(?<absoluteepisode>(?<!\d+)\d{3}(\.\d{1,2})?(?!\d+)))+.+?\[(?<subgroup>.+?)\](?:$|\.mkv)/i,
+  ),
+  absoluteEpisode(
+    'anime-title-episode-absolute-subgroup',
+    /^(?<title>.+?)[-_. ]Episode(?:[-_. ]+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-title-absolute-subgroup-hash',
+    /^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{3}(\.\d{1,2})(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-absolute-ep-range',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:_|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,3}(\.\d{1,2})?)-(?<absoluteepisode1>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-)).*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-absolute-number-range',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)[_. ]+(?<absoluteepisode>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+))-(?<absoluteepisode1>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-))(?:_|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
+  ),
+  absoluteEpisode(
+    'anime-title-absolute-hash',
+    /^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?[-_. ]+.*?(?<hash>\[\w{8}\])(?:$|\.)/i,
+  ),
+  seasonEpisode(
+    'airdate-plus-season-episode',
+    /^(?<title>.+?)?\W*(?<airdate>\d{4}\W+[0-1][0-9]\W+[0-3][0-9])(?!\W+[0-3][0-9])[-_. ](?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))/i,
+  ),
+  airDate(
+    'airdate-and-season-episode',
+    /^(?<title>.+?)?\W*(?<airyear>\d{4})\W+(?<airmonth>[0-1][0-9])\W+(?<airday>[0-3][0-9])(?!\W+[0-3][0-9]).+?(?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))/i,
+  ),
+  seasonEpisode(
+    'four-digit-season-s-episode',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:e|\We|_){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|e|\We|_){1,2}(?<episode1>\d{2,3}(?!\d+)))*)\W?(?!\\)/i,
+  ),
+  seasonEpisode(
+    'four-digit-season-x-episode',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:x|\Wx){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:-|x|\Wx|_){1,2}(?<episode1>\d{2,3}(?!\d+)))*)\W?(?!\\)/i,
+  ),
+  seasonPack(
+    'multi-season-pack',
+    /^(?<title>.+?)[-_. ]+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))\W?-\W?S?(?<season1>(?<!\d+)(?:\d{1,2})(?!\d+))/i,
+  ),
+  partialSeason(
+    'partial-season-pack',
+    /^(?<title>.+?)(?:\W+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))\W+(?:(?:Part\W?|(?<!\d+\W+)e)(?<seasonpart>\d{1,2}(?!\d+)))+)/i,
+  ),
+  seasonEpisode(
+    'miniseries-year-title-part-number',
+    /^(?<title>.+?\d{4})(?:\W+(?:(?:Part\W?|e)(?<episode>\d{1,2}(?!\d+)))+)/i,
+  ),
+  seasonEpisode(
+    'miniseries-multi-episode',
+    /^(?<title>.+?)(?:[-._ ][e])(?<episode>\d{2,3}(?!\d+))(?:(?:-?[e])(?<episode1>\d{2,3}(?!\d+)))+/i,
+  ),
+  seasonEpisode(
+    'miniseries-part-number',
+    /^(?<title>.+?)(?:\W+(?:(?:Part\W?|(?<!\d+\W+)e)(?<episode>\d{1,2}(?!\d+)))+)/i,
+  ),
+  seasonEpisode(
+    'miniseries-part-word',
+    /^(?<title>.+?)(?:\W+(?:Part[-._ ](?<episode>One|Two|Three|Four|Five|Six|Seven|Eight|Nine)(>[-._ ])))/i,
+  ),
+  seasonEpisode(
+    'miniseries-x-of-y',
+    /^(?<title>.+?)(?:\W+(?:(?<episode>(?<!\d+)\d{1,2}(?!\d+))of\d+)+)/i,
+  ),
+  seasonEpisode(
+    'season-episode-words',
+    /(?:.*(?:""|^))(?<title>.*?)(?:[-_\W](?<![()[]))+(?:\W?Season\W?)(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)+(?:Episode\W)(?:[-_. ]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+/i,
+  ),
+  seasonEpisode(
+    'multi-episode-square-brackets',
+    /(?:.*(?:^))(?<title>.*?)[-._ ]+\[S(?<season>(?<!\d+)\d{2}(?!\d+))(?:[E-]{1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))+\]/i,
+  ),
+  seasonEpisode(
+    'multi-episode-no-space-before-season',
+    /(?:.*(?:^))(?<title>.*?)S(?<season>(?<!\d+)\d{2}(?!\d+))(?:E(?<episode>(?<!\d+)\d{2}(?!\d+)))+/i,
+  ),
+  seasonEpisode(
+    'single-episode-ep-label',
+    /(?:.*(?:""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)?Ep?[ ._]?(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
+  ),
+  seasonEpisode(
+    'three-digit-season',
+    /(?:.*(?:""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{3}(?!\d+))(?:\W|_)?E(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
+  ),
+  seasonEpisode(
+    'five-digit-episode-with-title',
+    /^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))/i,
+  ),
+  seasonEpisode(
+    'five-digit-multi-episode-with-title',
+    /^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:[-_. ]{1,3}ep){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))+/i,
+  ),
+  seasonEpisode(
+    'separated-season-and-episode',
+    /^(?<title>.+?)(?:_|-|\s|\.)+S(?<season>\d{2}(?!\d+))(\W-\W)E(?<episode>(?<!\d+)\d{2}(?!\d+))(?!\\)/i,
+  ),
+  absoluteEpisode(
+    'anime-title-with-season-number-absolute',
+    /^(?<title>.+?S\d{1,2})[-_. ]{3,}(?:EP)?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))/i,
+  ),
+  absoluteEpisode(
+    'anime-french-title-single-episode',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)[-_. ]+?(?:Episode[-_. ]+?)(?<absoluteepisode>\d{1}(\.\d{1,2})?(?!\d+))/i,
+  ),
+  seasonPack(
+    'season-only',
+    /^(?<title>.+?)\W(?:S|Season)\W?(?<season>\d{1,2}(?!\d+))(\W+|_|$)(?<extras>EXTRAS|SUBPACK)?(?!\\)/i,
+  ),
+  seasonPack(
+    'four-digit-season-only',
+    /^(?<title>.+?)\W(?:S|Season)\W?(?<season>\d{4}(?!\d+))(\W+|_|$)(?<extras>EXTRAS|SUBPACK)?(?!\\)/i,
+  ),
+  seasonEpisode(
+    'season-episode-square-brackets',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+\[S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+|i|p)))+\])\W?(?!\\)/i,
+  ),
+  seasonEpisode(
+    'three-digit-episode-numbering',
+    /^(?<title>.+?)?(?:(?:[_.](?<![()[!]))+(?<season>(?<!\d+)[1-9])(?<episode>[1-9][0-9]|[0][1-9])(?![a-z]|\d+))+(?:[_.]|$)/i,
+  ),
+  seasonEpisode(
+    'four-digit-episode-number-no-title',
+    /^(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)(\W+|_|$)(?!\\)/i,
+  ),
+  seasonEpisode(
+    'four-digit-episode-number-with-title',
+    /^(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)\W?(?!\\)/i,
+  ),
+  airDate(
+    'ymd-airdate',
+    /^(?<title>.+?)?\W*(?<airyear>\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])(?![-_. ]+[0-3][0-9])/i,
+  ),
+  airDate(
+    'mdy-airdate',
+    /^(?<title>.+?)?\W*(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])[-_. ]+(?<airyear>\d{4})(?!\d+)/i,
+  ),
+  seasonEpisode(
+    'four-digit-scene-numbering',
+    /^(?<title>.+?)?(?:(?:[-_\W](?<![()[!]))*(?<season>(?<!\d+|\(|\[|e|x)\d{2})(?<episode>(?<!e|x)\d{2}(?!p|i|\d+|\)|\]|\W\d+|\W(?:e|ep|x)\d+)))+(\W+|_|$)(?!\\)/i,
+  ),
+  seasonEpisode(
+    'single-digit-episode',
+    /^(?<title>.*?)(?:(?:[-_\W](?<![()[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:-|[ex]){1,2}(?<episode>\d{1}))+)+(\W+|_|$)(?!\\)/i,
+  ),
+  seasonEpisode(
+    'itunes-season-folder',
+    /^(?:Season(?:_|-|\s|\.)(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:_|-|\s|\.)(?<episode>(?<!\d+)\d{1,2}(?!\d+))/i,
+  ),
+  seasonEpisode(
+    'itunes-season-episode',
+    /^(?:(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:-(?<episode>\d{2,3}(?!\d+))))/i,
+  ),
+  absoluteEpisode(
+    'anime-absolute-ep-label',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:_|-|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,4}(\.\d{1,2})?))+.*?(?<hash>\[\w{8}\])?(?:$|\.)/i,
+  ),
+  absoluteEpisode(
+    'anime-title-episode-absolute',
+    /^(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
+  ),
+  absoluteEpisode(
+    'anime-title-absolute-number',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
+  ),
+  absoluteEpisode(
+    'anime-title-braced-absolute-number',
+    /^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:[-_\W](?<![()[!]))+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?/i,
+  ),
+  seasonEpisode(
+    'extant-multi-episode-numbering',
+    /^(?<title>.+?)[-_. ](?<season>[0]?\d?)(?:(?<episode>\d{2}){2}(?!\d+))[-_. ]/i,
+  ),
+];
+
+export const rejectedPatterns = [
+  /^[0-9a-zA-Z]{32}/i,
+  /^[a-z0-9]{24}$/i,
+  /"^[A-Z]{11}\d{3}$/i,
+  /"^[a-z]{12}\d{3}$/i,
+  /^Backup_\d{5,}S\d{2}-\d{2}$/i,
+  /^123$"/,
+  /^abc$"/i,
+  /^b00bs$"/i,
+  /^\d{6}_\d{2}$"/,
+];

--- a/test/season.spec.ts
+++ b/test/season.spec.ts
@@ -199,6 +199,7 @@ for (const [postTitle, title, specialEpisodeNumber] of animeRecapCases) {
     expect(result.seriesTitle).toBe(title);
     expect(result.episodeNumbers.length).toBe(1);
     expect(result.episodeNumbers[0]).toBe(specialEpisodeNumber);
+    expect(result.isSpecial).toBe(true);
     expect(result.fullSeason).toBe(false);
   });
 }
@@ -466,6 +467,7 @@ for (const [postTitle, title, absoluteEpisodeNumber, seasonNumber] of absoluteEp
     expect(result.episodeNumbers.length).toBe(1);
     expect(result.episodeNumbers[0]).toBe(absoluteEpisodeNumber);
     expect(result.seasons[0] ?? 0).toBe(seasonNumber);
+    expect(result.isSpecial).toBe(false);
     expect(result.fullSeason).toBe(false);
   });
 }

--- a/test/season.spec.ts
+++ b/test/season.spec.ts
@@ -97,6 +97,41 @@ for (const [postTitle, title, season, seasonPart] of partialSeasonPackCases) {
   });
 }
 
+it('keeps representative season parser shapes working', () => {
+  expect(
+    parseSeason('Jimmy Fallon 2019 10 23 Michael Douglas 1080p HEVC x265-MeGusta'),
+  ).toMatchObject({
+    seriesTitle: 'Jimmy Fallon',
+    airDate: new Date(2019, 9, 23),
+  });
+  expect(parseSeason('The Simpsons S01 - S10 FIXED MegaPack x264 AC3-DTS -jlw')).toMatchObject({
+    seriesTitle: 'The Simpsons',
+    seasons: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    isMultiSeason: true,
+  });
+  expect(parseSeason('The.Ranch.2016.S02.Part.1.1080p.NF.WEBRip.DD5.1.x264-NTb')).toMatchObject({
+    seriesTitle: 'The Ranch 2016',
+    seasons: [2],
+    isPartialSeason: true,
+    seasonPart: 1,
+  });
+  expect(parseSeason('Lie.to.Me.S03.SUBPACK.DVDRip.XviD-REWARD')).toMatchObject({
+    seriesTitle: 'Lie to Me',
+    seasons: [3],
+    fullSeason: true,
+    isSeasonExtra: true,
+  });
+  expect(parseSeason('Great British Railway Journeys S11E03 480p x264-mSD [eztv]')).toMatchObject({
+    seriesTitle: 'Great British Railway Journeys',
+    seasons: [11],
+    episodeNumbers: [3],
+  });
+  expect(parseSeason('[HorribleSubs] Shirobako - 20 [720p].mkv')).toMatchObject({
+    seriesTitle: 'Shirobako',
+    episodeNumbers: [20],
+  });
+});
+
 const crapCases: Array<[string]> = [
   ['76El6LcgLzqb426WoVFg1vVVVGx4uCYopQkfjmLe'],
   ['Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8'],
@@ -212,6 +247,23 @@ for (const [postTitle, title, season] of seasonExtraCases) {
 //     t.is(result.seasons[0], seasonNumber);
 //   });
 // }
+
+const absoluteEpisodeRangeCases: Array<[string, string, number[]]> = [
+  ['Anime Range ep01-12 [ABCDEF12]', 'Anime Range', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]],
+  ['Anime Range 1-10 [ABCDEF12]', 'Anime Range', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
+];
+for (const [postTitle, title, episodeNumbers] of absoluteEpisodeRangeCases) {
+  it(`expands absolute episode ranges ${postTitle}`, () => {
+    const result = parseSeason(postTitle)!;
+    expect(result.seriesTitle).toBe(title);
+    expect(result.episodeNumbers).toEqual(episodeNumbers);
+  });
+}
+
+it('does not expand descending absolute episode ranges', () => {
+  const result = parseSeason('Anime Range ep12-01 [ABCDEF12]');
+  expect(result?.episodeNumbers).not.toEqual([12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+});
 
 const absoluteEpisodeCases: Array<[string, string, number, number]> = [
   ['[SubDESU]_High_School_DxD_07_(1280x720_x264-AAC)_[6B7FD717]', 'High School DxD', 7, 0],


### PR DESCRIPTION
The season parser had one huge regex list feeding one generic optional-capture mapper. This keeps the public API the same, but moves matching into named pattern entries with shape-specific parsers so the branching is easier to reason about.

Also fixes absolute episode ranges while we're in here and adds tests for the range cases plus representative parser shapes.