### PR TITLE
fix(title): Preserve multi prefix in movie titles

### DIFF
--- a/src/title/cleanup.ts
+++ b/src/title/cleanup.ts
@@ -88,7 +88,7 @@ export function simplifyTitle(title: string): string {
 const requestInfoRegex = /\[[^\]\r\n]+\]/i;
 const editionExp =
   /\b(?:(?:(?:Extended|Ultimate)[-_. ']*)?(?:(?:Director|Collector)[-_. ']*s?|Theatrical|Anniversary|The[-_. ']*Uncut|DC|Ultimate|Final(?=[-_. ']*(?:Cut|Edition|Version))|Extended|Special|Despecialized|unrated|\d{2,3}(?:th)?[-_. ']*Anniversary)(?:[-_. ']*(?:Cut|Edition|Version))?(?:[-_. ']*(?:Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit))?|(?:Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit|Edition|Restored|[234]in1)){1,3}/i;
-const languageExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)/i;
+const languageExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)\b/i;
 const sceneGarbageExp = /\b(PROPER|REAL|READ.NFO)/;
 
 // Hoisted global variants

--- a/test/filenameParse.spec.ts
+++ b/test/filenameParse.spec.ts
@@ -192,6 +192,45 @@ const movieCases: Array<[string, any]> = [
     },
   ],
   [
+    'Multiplicity (1996) [REPACK] [720p]',
+    {
+      resolution: Resolution.R720P,
+      title: 'Multiplicity',
+      year: '1996',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Multiplicity.1996.1080p.BluRay.X264-AMIABLE',
+    {
+      resolution: Resolution.R1080P,
+      title: 'Multiplicity',
+      year: '1996',
+      group: 'AMIABLE',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Doctor.Strange.in.the.Multiverse.of.Madness.2022.2160p.UHD.BluRay.x265-SURCODE',
+    {
+      resolution: Resolution.R2160P,
+      title: 'Doctor Strange in the Multiverse of Madness',
+      year: '2022',
+      group: 'SURCODE',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Doctor.Strange.in.the.Multiverse.of.Madness.2022.2160p.WEB.H265-SLOT',
+    {
+      resolution: Resolution.R2160P,
+      title: 'Doctor Strange in the Multiverse of Madness',
+      year: '2022',
+      group: 'SLOT',
+      languages: [Language.English],
+    },
+  ],
+  [
     'Spider-Man Far from Home.2019.1080p.HDRip.X264.AC3-EVO',
     {
       resolution: Resolution.R1080P,

--- a/test/title.spec.ts
+++ b/test/title.spec.ts
@@ -53,6 +53,17 @@ const cases: Array<[string, { title: string; year: string | null }]> = [
   ],
   ['The.Middle.720p.HEVC.x265-MeGusta-Pre', { title: 'The Middle', year: null }],
   ['The.Middle.HEVC.x265-MeGusta-Pre', { title: 'The Middle', year: null }],
+  ['Multiplicity (1996) [REPACK] [720p]', { title: 'Multiplicity', year: '1996' }],
+  ['Multiplicity.1996.1080p.BluRay.X264-AMIABLE', { title: 'Multiplicity', year: '1996' }],
+  ['Multiverse (2024) 720p WEB-DL', { title: 'Multiverse', year: '2024' }],
+  [
+    'Doctor.Strange.in.the.Multiverse.of.Madness.2022.2160p.UHD.BluRay.x265-SURCODE',
+    { title: 'Doctor Strange in the Multiverse of Madness', year: '2022' },
+  ],
+  [
+    'Doctor.Strange.in.the.Multiverse.of.Madness.2022.2160p.WEB.H265-SLOT',
+    { title: 'Doctor Strange in the Multiverse of Madness', year: '2022' },
+  ],
   ['Blade Runner 2049 2017', { title: 'Blade Runner 2049', year: '2017' }],
   ['Blade Runner 2049 (2017)', { title: 'Blade Runner 2049', year: '2017' }],
   [


### PR DESCRIPTION
Movie titles like Multiplicity and Multiverse were losing their leading `Multi` because title cleanup treated it as a language marker inside a larger word.

Keep `MULTI` cleanup to standalone tokens and add real release-name regressions.

Fixes #80