### PR TITLE
fix(title): Trim release metadata from title suffix

### DIFF
--- a/src/title/cleanup.ts
+++ b/src/title/cleanup.ts
@@ -86,21 +86,35 @@ export function simplifyTitle(title: string): string {
 }
 
 const requestInfoRegex = /\[[^\]\r\n]+\]/i;
-const editionExp =
-  /\b(?:(?:(?:Extended|Ultimate)[-_. ']*)?(?:(?:Director|Collector)[-_. ']*s?|Theatrical|Anniversary|The[-_. ']*Uncut|DC|Ultimate|Final(?=[-_. ']*(?:Cut|Edition|Version))|Extended|Special|Despecialized|unrated|\d{2,3}(?:th)?[-_. ']*Anniversary)(?:[-_. ']*(?:Cut|Edition|Version))?(?:[-_. ']*(?:Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit))?|(?:Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit|Edition|Restored|[234]in1)){1,3}/i;
+const editionMarkerPattern = String.raw`(?:(?:(?:Extended|Ultimate)[-_. ']*)?(?:(?:Director|Collector)[-_. ']*s?[-_. ']*(?:Cut|Edition|Version)|Theatrical|Anniversary|The[-_. ']*Uncut|DC|Ultimate|Final(?=[-_. ']*(?:Cut|Edition|Version))|Extended|Special|Despecialized|unrated|\d{2,3}(?:th)?[-_. ']*Anniversary)(?:[-_. ']*(?:Cut|Edition|Version))?(?:[-_. ']*(?:Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit))?|(?:Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit|Edition|Restored|[234]in1)){1,3}`;
+const trailingLanguageMarkerPattern = String.raw`(?:${Object.values(Language).join('|')}|TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)`;
+const editionSuffixExp = new RegExp(
+  String.raw`(?:^|[-_. '([]+)${editionMarkerPattern}(?:[-_. ']+${trailingLanguageMarkerPattern})*[-_. ')\]]*$`,
+  'i',
+);
 const languageExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)\b/i;
-const sceneGarbageExp = /\b(PROPER|REAL|READ.NFO)/;
-
-// Hoisted global variants
-const sceneGarbageGlobalExp = new RegExp(sceneGarbageExp.source, 'ig');
+const sceneGarbageSuffixExp = /(?:^|[-_. ']+)(?:PROPER|REAL|READ.NFO)(?:[-_. ']+(?:PROPER|REAL|READ.NFO))*[-_. ']*$/i;
+const titleContentExp = /[a-z0-9]/i;
 
 // Precomputed combined regex for all language names (replaces loop creating ~45 regexes per call)
 const allLanguagesGlobalExp = new RegExp(
   `\\b(${Object.values(Language)
     .map(l => l.toUpperCase())
-    .join('|')})`,
+    .join('|')})\\b`,
   'g',
 );
+
+function removeEditionSuffix(title: string): string {
+  const cleanedTitle = title.replace(editionSuffixExp, '');
+
+  return titleContentExp.test(cleanedTitle) ? cleanedTitle : title;
+}
+
+function removeSceneGarbageSuffix(title: string): string {
+  const cleanedTitle = title.replace(sceneGarbageSuffixExp, '');
+
+  return titleContentExp.test(cleanedTitle) ? cleanedTitle : title;
+}
 
 const releaseTitleCleanupPasses: readonly CleanupPass[] = [
   {
@@ -124,7 +138,7 @@ const releaseTitleCleanupPasses: readonly CleanupPass[] = [
   },
   {
     name: 'remove edition marker',
-    pattern: editionExp,
+    clean: removeEditionSuffix,
     trimAfter: true,
   },
   {
@@ -134,7 +148,7 @@ const releaseTitleCleanupPasses: readonly CleanupPass[] = [
   },
   {
     name: 'remove scene garbage marker',
-    pattern: sceneGarbageGlobalExp,
+    clean: removeSceneGarbageSuffix,
     trimAfter: true,
   },
   {

--- a/src/title/cleanup.ts
+++ b/src/title/cleanup.ts
@@ -93,7 +93,8 @@ const editionSuffixExp = new RegExp(
   'i',
 );
 const languageExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)\b/i;
-const sceneGarbageSuffixExp = /(?:^|[-_. ']+)(?:PROPER|REAL|READ.NFO)(?:[-_. ']+(?:PROPER|REAL|READ.NFO))*[-_. ']*$/i;
+const sceneGarbageSuffixExp =
+  /(?:^|[-_. ']+)(?:PROPER|REAL|READ.NFO)(?:[-_. ']+(?:PROPER|REAL|READ.NFO))*[-_. ']*$/i;
 const titleContentExp = /[a-z0-9]/i;
 
 // Precomputed combined regex for all language names (replaces loop creating ~45 regexes per call)

--- a/src/title/cleanup.ts
+++ b/src/title/cleanup.ts
@@ -85,36 +85,70 @@ export function simplifyTitle(title: string): string {
   return applyCleanupPasses(title, simplifyTitleCleanupPasses).trim();
 }
 
-const requestInfoRegex = /\[[^\]\r\n]+\]/i;
 const editionMarkerPattern = String.raw`(?:(?:(?:Extended|Ultimate)[-_. ']*)?(?:(?:Director|Collector)[-_. ']*s?[-_. ']*(?:Cut|Edition|Version)|Theatrical|Anniversary|The[-_. ']*Uncut|DC|Ultimate|Final(?=[-_. ']*(?:Cut|Edition|Version))|Extended|Special|Despecialized|unrated|\d{2,3}(?:th)?[-_. ']*Anniversary)(?:[-_. ']*(?:Cut|Edition|Version))?(?:[-_. ']*(?:Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit))?|(?:Uncensored|Remastered|Unrated|Uncut|IMAX|Fan[-_. ']*Edit|Edition|Restored|[234]in1)){1,3}`;
 const trailingLanguageMarkerPattern = String.raw`(?:${Object.values(Language).join('|')}|TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)`;
 const editionSuffixExp = new RegExp(
   String.raw`(?:^|[-_. '([]+)${editionMarkerPattern}(?:[-_. ']+${trailingLanguageMarkerPattern})*[-_. ')\]]*$`,
   'i',
 );
-const languageExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)\b/i;
+const releaseBoundaryExp = new RegExp(
+  String.raw`[-_. ']+(?:${commonSourceMarkerExp.source}|${webdlExp.source}|${codecExp.source})`,
+  'i',
+);
+const requestInfoSuffixExp = /(?:^|[-_. ']+)\[[^\]\r\n]+\][-_. ']*$/i;
+const languageMarkerSuffixExp = /\b(TRUE.?FRENCH|videomann|SUBFRENCH|PLDUB|MULTI)\b[-_. ']*$/i;
+const languageNameSuffixExp = new RegExp(
+  String.raw`(?:^|[-_. ']+)(?:${Object.values(Language)
+    .map(l => l.toUpperCase())
+    .join('|')})[-_. ']*$`,
+);
 const sceneGarbageSuffixExp =
   /(?:^|[-_. ']+)(?:PROPER|REAL|READ.NFO)(?:[-_. ']+(?:PROPER|REAL|READ.NFO))*[-_. ']*$/i;
 const titleContentExp = /[a-z0-9]/i;
 
-// Precomputed combined regex for all language names (replaces loop creating ~45 regexes per call)
-const allLanguagesGlobalExp = new RegExp(
-  `\\b(${Object.values(Language)
-    .map(l => l.toUpperCase())
-    .join('|')})\\b`,
-  'g',
-);
+const trailingMetadataSuffixExps = [
+  requestInfoSuffixExp,
+  languageMarkerSuffixExp,
+  languageNameSuffixExp,
+  sceneGarbageSuffixExp,
+  editionSuffixExp,
+];
 
-function removeEditionSuffix(title: string): string {
-  const cleanedTitle = title.replace(editionSuffixExp, '');
-
+function removeTitleSuffix(title: string, suffixExp: RegExp): string {
+  suffixExp.lastIndex = 0;
+  const cleanedTitle = title.replace(suffixExp, '');
   return titleContentExp.test(cleanedTitle) ? cleanedTitle : title;
 }
 
-function removeSceneGarbageSuffix(title: string): string {
-  const cleanedTitle = title.replace(sceneGarbageSuffixExp, '');
+// Release metadata should only trim the right edge. Title words that look like
+// metadata, such as "Collector" or "Real", must survive inside the title.
+function trimTrailingReleaseMetadata(title: string): string {
+  let trimmedTitle = title.trim();
+  let removedSuffix = true;
 
-  return titleContentExp.test(cleanedTitle) ? cleanedTitle : title;
+  while (removedSuffix) {
+    removedSuffix = false;
+
+    for (const suffixExp of trailingMetadataSuffixExps) {
+      const cleanedTitle = removeTitleSuffix(trimmedTitle, suffixExp).trim();
+      if (cleanedTitle !== trimmedTitle) {
+        trimmedTitle = cleanedTitle;
+        removedSuffix = true;
+        break;
+      }
+    }
+  }
+
+  return trimmedTitle;
+}
+
+// Handles full release strings passed directly into the title cleaner. This is
+// intentionally separator-based so bare title substrings do not become cut points.
+function truncateAtReleaseMetadataBoundary(title: string): string {
+  releaseBoundaryExp.lastIndex = 0;
+  const match = releaseBoundaryExp.exec(title);
+
+  return match && match.index > 0 ? title.slice(0, match.index) : title;
 }
 
 const releaseTitleCleanupPasses: readonly CleanupPass[] = [
@@ -123,38 +157,13 @@ const releaseTitleCleanupPasses: readonly CleanupPass[] = [
     clean: title => title.replace('_', ' '),
   },
   {
-    name: 'remove request info',
-    pattern: requestInfoRegex,
+    name: 'truncate at release metadata boundary',
+    clean: truncateAtReleaseMetadataBoundary,
     trimAfter: true,
   },
   {
-    name: 'remove common source markers',
-    pattern: commonSourceMarkersGlobalExp,
-    trimAfter: true,
-  },
-  {
-    name: 'remove web download marker',
-    pattern: webdlExp,
-    trimAfter: true,
-  },
-  {
-    name: 'remove edition marker',
-    clean: removeEditionSuffix,
-    trimAfter: true,
-  },
-  {
-    name: 'remove language marker',
-    pattern: languageExp,
-    trimAfter: true,
-  },
-  {
-    name: 'remove scene garbage marker',
-    clean: removeSceneGarbageSuffix,
-    trimAfter: true,
-  },
-  {
-    name: 'remove language names',
-    pattern: allLanguagesGlobalExp,
+    name: 'trim trailing release metadata',
+    clean: trimTrailingReleaseMetadata,
     trimAfter: true,
   },
   {

--- a/test/filenameParse.spec.ts
+++ b/test/filenameParse.spec.ts
@@ -231,6 +231,76 @@ const movieCases: Array<[string, any]> = [
     },
   ],
   [
+    'The.Bone.Collector.1999.2160p.UHD.BluRay.x265-B0MBARDiERS',
+    {
+      resolution: Resolution.R2160P,
+      title: 'The Bone Collector',
+      year: '1999',
+      group: 'B0MBARDiERS',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'The.Collector.2009.1080p.BluRay.X264-AMIABLE',
+    {
+      resolution: Resolution.R1080P,
+      title: 'The Collector',
+      year: '2009',
+      group: 'AMIABLE',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Uncut.Gems.2019.2160p.UHD.BluRay.x265-B0MBARDiERS',
+    {
+      resolution: Resolution.R2160P,
+      title: 'Uncut Gems',
+      year: '2019',
+      group: 'B0MBARDiERS',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'A.Real.Pain.2024.1080p.WEB.H264-GROUP',
+    {
+      resolution: Resolution.R1080P,
+      title: 'A Real Pain',
+      year: '2024',
+      group: 'GROUP',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Real.Steel.2011.1080p.BluRay.x264-GROUP',
+    {
+      resolution: Resolution.R1080P,
+      title: 'Real Steel',
+      year: '2011',
+      group: 'GROUP',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Reality.2023.1080p.WEB.H264-GROUP',
+    {
+      resolution: Resolution.R1080P,
+      title: 'Reality',
+      year: '2023',
+      group: 'GROUP',
+      languages: [Language.English],
+    },
+  ],
+  [
+    'Polish.Wedding.1998.1080p.WEB.H264-GROUP',
+    {
+      resolution: Resolution.R1080P,
+      title: 'Polish Wedding',
+      year: '1998',
+      group: 'GROUP',
+      languages: [Language.English],
+    },
+  ],
+  [
     'Spider-Man Far from Home.2019.1080p.HDRip.X264.AC3-EVO',
     {
       resolution: Resolution.R1080P,

--- a/test/title.spec.ts
+++ b/test/title.spec.ts
@@ -75,10 +75,7 @@ const cases: Array<[string, { title: string; year: string | null }]> = [
     { title: 'The Bone Collector', year: '1999' },
   ],
   ['The.Collector.2009.1080p.BluRay.X264-AMIABLE', { title: 'The Collector', year: '2009' }],
-  [
-    'Uncut.Gems.2019.2160p.UHD.BluRay.x265-B0MBARDiERS',
-    { title: 'Uncut Gems', year: '2019' },
-  ],
+  ['Uncut.Gems.2019.2160p.UHD.BluRay.x265-B0MBARDiERS', { title: 'Uncut Gems', year: '2019' }],
   ['A.Real.Pain.2024.1080p.WEB.H264-GROUP', { title: 'A Real Pain', year: '2024' }],
   ['Real.Steel.2011.1080p.BluRay.x264-GROUP', { title: 'Real Steel', year: '2011' }],
   ['Reality.2023.1080p.WEB.H264-GROUP', { title: 'Reality', year: '2023' }],

--- a/test/title.spec.ts
+++ b/test/title.spec.ts
@@ -71,6 +71,19 @@ const cases: Array<[string, { title: string; year: string | null }]> = [
     { title: 'Scarface', year: '1983' },
   ],
   [
+    'The.Bone.Collector.1999.2160p.UHD.BluRay.x265-B0MBARDiERS',
+    { title: 'The Bone Collector', year: '1999' },
+  ],
+  ['The.Collector.2009.1080p.BluRay.X264-AMIABLE', { title: 'The Collector', year: '2009' }],
+  [
+    'Uncut.Gems.2019.2160p.UHD.BluRay.x265-B0MBARDiERS',
+    { title: 'Uncut Gems', year: '2019' },
+  ],
+  ['A.Real.Pain.2024.1080p.WEB.H264-GROUP', { title: 'A Real Pain', year: '2024' }],
+  ['Real.Steel.2011.1080p.BluRay.x264-GROUP', { title: 'Real Steel', year: '2011' }],
+  ['Reality.2023.1080p.WEB.H264-GROUP', { title: 'Reality', year: '2023' }],
+  ['Polish.Wedding.1998.1080p.WEB.H264-GROUP', { title: 'Polish Wedding', year: '1998' }],
+  [
     'Movie.Title.Directors.Cut.2019.1080p.BluRay.x264-GROUP',
     { title: 'Movie Title', year: '2019' },
   ],


### PR DESCRIPTION
Title cleanup was treating edition and scene words as removable metadata even when they were part of the actual movie title, so examples like The Collector, Uncut Gems, and Real Steel lost words.

Move release-title cleanup to a suffix trimmer: metadata can trim the right edge, and full release strings still get a separator-based metadata boundary before title formatting. Adds real filename regressions for the broken cases.

Follow-up to #80