### PR TITLE
feat(season): Add episode remainder parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ console.log(filenameParse('The Office US S09E06 HDTV XviD-AFG', true));
 //   "seasonPart": 0,
 //   "isTv": true
 // }
+
+console.log(filenameParse('The Expanse - S01E02 - The Big Empty', true).remainder);
+// "The Big Empty"
 ```
 
 Quality modifiers such as `Remux`, `BR-DISK`, and `Raw-HD` are exposed as `modifier`.

--- a/src/filenameParse.ts
+++ b/src/filenameParse.ts
@@ -84,6 +84,7 @@ export function filenameParse(name: string, isTv = false): ParsedFilename {
       const seasonResult: ParsedTvInfo = {
         seasons: season.seasons,
         episodeNumbers: season.episodeNumbers,
+        ...(season.remainder ? { remainder: season.remainder } : {}),
         airDate: season.airDate,
         fullSeason: season.fullSeason,
         isPartialSeason: season.isPartialSeason,

--- a/src/season/common.ts
+++ b/src/season/common.ts
@@ -1,6 +1,14 @@
+import { releaseTitleCleaner } from '../title/cleanup.js';
+import { releaseGroupSuffixExp } from '../title/patterns.js';
+
 const requestInfoExp = /^(?:\[[^\]\r\n]+\])+/;
 const sixDigitAirDateMatchExp =
   /"(?<=[_.-])(?<airdate>(?<!\d)(?<airyear>[1-9]\d{1})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9]))(?=[_.-])/i;
+const trailingRemainderRequestInfoExp = /(?:\s*\[[^\]\r\n]+\])+$/;
+const leadingRemainderSeparatorsExp = /^[-_.\s]+/;
+const leadingReleaseMetadataExp =
+  /^(?:[ip][-_.\s]+[xh][-. ]?26[45]|(?:1[89]|20)\d{2}|480[ip]|576[ip]|720[ip]|1080[ip]|2160[ip]|WEB(?:[-_. ]?DL|Rip)?|Blu[-_. ]?Ray|HDTV|DVD(?:Rip)?|BDRip|BRRip|[xh][-. ]?26[45]|h[-. ]?26[45]|HEVC|XviD)\b/i;
+const remainderContentExp = /[a-z]/i;
 
 export interface ParsedMatchCollection {
   seriesName: string;
@@ -15,6 +23,7 @@ export interface ParsedMatchCollection {
   fullSeason?: boolean;
   airDate?: Date;
   releaseTokens?: string;
+  remainder?: string;
 }
 
 type MatchGroups = NonNullable<RegExpExecArray['groups']>;
@@ -177,12 +186,12 @@ function parseSeasonEpisodeGroups(
 ): ParsedMatchCollection | null {
   const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
   const nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
-  const episodeResult = applyEpisodeNumbers(result, groups);
+  const episodeResult = applyEpisodeNumbers(result, groups, simpleTitle, nextIndex);
   if (episodeResult === null) {
     return null;
   }
 
-  return finishResult(result, simpleTitle, nextIndex);
+  return finishResult(result, simpleTitle, episodeResult);
 }
 
 function parseSeasonPackGroups(
@@ -224,10 +233,12 @@ function parseAbsoluteEpisodeGroups(
 ): ParsedMatchCollection | null {
   const { result, lastTokenIndex } = createBaseResult(groups, simpleTitle);
   let nextIndex = applySeasonNumbers(result, groups, simpleTitle, lastTokenIndex);
-  const episodeResult = applyEpisodeNumbers(result, groups);
+  const episodeResult = applyEpisodeNumbers(result, groups, simpleTitle, nextIndex);
   if (episodeResult === null) {
     return null;
   }
+
+  nextIndex = episodeResult;
 
   const absoluteResult = applyAbsoluteEpisodeNumbers(result, groups);
   if (absoluteResult === null) {
@@ -273,7 +284,7 @@ function applySeasonNumbers(
   let seasons = [groupValue(groups, 'season'), groupValue(groups, 'season1')]
     .filter(isPresent)
     .map(x => {
-      nextIndex = Math.max(indexOfEnd(simpleTitle, x), nextIndex);
+      nextIndex = Math.max(indexOfEndAfter(simpleTitle, x, nextIndex), nextIndex);
       return Number(x);
     });
 
@@ -289,12 +300,17 @@ function applySeasonNumbers(
   return nextIndex;
 }
 
-function applyEpisodeNumbers(result: ParsedMatchCollection, groups: MatchGroups): null | undefined {
+function applyEpisodeNumbers(
+  result: ParsedMatchCollection,
+  groups: MatchGroups,
+  simpleTitle: string,
+  lastTokenIndex: number,
+): number | null {
   const episodeCaptures = [groupValue(groups, 'episode'), groupValue(groups, 'episode1')].filter(
     isPresent,
   );
   if (episodeCaptures.length === 0) {
-    return undefined;
+    return lastTokenIndex;
   }
 
   const first = Number(episodeCaptures[0]);
@@ -305,7 +321,13 @@ function applyEpisodeNumbers(result: ParsedMatchCollection, groups: MatchGroups)
   }
 
   result.episodeNumbers = range;
-  return undefined;
+
+  let nextIndex = lastTokenIndex;
+  for (const episodeCapture of episodeCaptures) {
+    nextIndex = Math.max(indexOfEndAfter(simpleTitle, episodeCapture, nextIndex), nextIndex);
+  }
+
+  return nextIndex;
 }
 
 function applyAbsoluteEpisodeNumbers(
@@ -361,12 +383,31 @@ function finishResult(
     lastTokenIndex === simpleTitle.length || lastTokenIndex === -1
       ? simpleTitle
       : simpleTitle.slice(lastTokenIndex);
+  const remainder =
+    result.episodeNumbers !== undefined && result.episodeNumbers.length > 0
+      ? parseRemainder(releaseTokens)
+      : undefined;
 
   return {
     ...result,
     releaseTokens,
+    ...(remainder ? { remainder } : {}),
     seriesTitle: result.seriesName,
   };
+}
+
+function parseRemainder(releaseTokens: string): string | undefined {
+  const rawRemainder = releaseTokens
+    .replace(trailingRemainderRequestInfoExp, '')
+    .replace(releaseGroupSuffixExp, '')
+    .replace(leadingRemainderSeparatorsExp, '');
+  if (leadingReleaseMetadataExp.test(rawRemainder)) {
+    return undefined;
+  }
+
+  const remainder = releaseTitleCleaner(rawRemainder);
+
+  return remainder !== null && remainderContentExp.test(remainder) ? remainder : undefined;
 }
 
 function groupValue(groups: MatchGroups, name: string): string | undefined {
@@ -416,5 +457,14 @@ function indexOfEnd(str1: string, str2: string): number {
   }
 
   const io = str1.indexOf(str2);
+  return io === -1 ? -1 : io + str2.length;
+}
+
+function indexOfEndAfter(str1: string, str2: string, startIndex: number): number {
+  if (str2.length === 0) {
+    return -1;
+  }
+
+  const io = str1.indexOf(str2, Math.max(0, startIndex));
   return io === -1 ? -1 : io + str2.length;
 }

--- a/src/season/index.ts
+++ b/src/season/index.ts
@@ -12,6 +12,7 @@ export interface Season {
   seriesTitle: string;
   seasons: number[];
   episodeNumbers: number[];
+  remainder?: string;
   airDate: Date | null;
   // Language: Language;
   fullSeason: boolean;
@@ -86,6 +87,7 @@ function toSeason(title: string, result: ParsedMatchCollection): Season {
     seriesTitle: result.seriesName,
     seasons: result.seasonNumbers ?? [],
     episodeNumbers: result.episodeNumbers ?? [],
+    ...(result.remainder ? { remainder: result.remainder } : {}),
     airDate: result.airDate ?? null,
     fullSeason: isSpecialFullSeason ? false : (result.fullSeason ?? false),
     isPartialSeason: result.isPartialSeason ?? false,

--- a/test/filenameParse.spec.ts
+++ b/test/filenameParse.spec.ts
@@ -378,6 +378,16 @@ const tvCases: Array<[string, any]> = [
       isTv: true,
     },
   ],
+  [
+    'The Expanse - S01E02 - The Big Empty',
+    {
+      title: 'The Expanse',
+      seasons: [1],
+      episodeNumbers: [2],
+      remainder: 'The Big Empty',
+      isTv: true,
+    },
+  ],
 ];
 for (const [title, result] of tvCases) {
   it(`parse tv show title "${title}"`, () => {

--- a/test/season.spec.ts
+++ b/test/season.spec.ts
@@ -84,6 +84,38 @@ for (const [postTitle, title, episodes] of multiEpisodeCases) {
   });
 }
 
+const remainderCases: Array<[string, string, number[], number[], string]> = [
+  ['The Expanse - S01E02 - The Big Empty', 'The Expanse', [1], [2], 'The Big Empty'],
+  [
+    'The.Expanse.S01E02.The.Big.Empty.1080p.WEB.H264-GROUP',
+    'The Expanse',
+    [1],
+    [2],
+    'The Big Empty',
+  ],
+  ['Show.S02E02.Episode.Title.1080p.WEB.H264-GROUP', 'Show', [2], [2], 'Episode Title'],
+];
+for (const [postTitle, title, seasons, episodes, remainder] of remainderCases) {
+  it(`parses remainder after episode tokens for "${postTitle}"`, () => {
+    expect(parseSeason(postTitle)).toMatchObject({
+      seriesTitle: title,
+      seasons,
+      episodeNumbers: episodes,
+      remainder,
+    });
+  });
+}
+
+const noRemainderCases: Array<[string]> = [
+  ['Great British Railway Journeys S11E03 480p x264-mSD [eztv]'],
+  ['The Morning Show S01E01-E03 2019 1080p WEBRip X264 AC3-EVO'],
+];
+for (const [postTitle] of noRemainderCases) {
+  it(`does not expose junk remainder for "${postTitle}"`, () => {
+    expect(parseSeason(postTitle)).not.toHaveProperty('remainder');
+  });
+}
+
 const partialSeasonPackCases: Array<[string, string, number, number]> = [
   ['The.Ranch.2016.S02.Part.1.1080p.NF.WEBRip.DD5.1.x264-NTb', 'The Ranch 2016', 2, 1],
 ];


### PR DESCRIPTION
TV releases can include useful text after the episode token, but we were throwing it away. This exposes a cleaned `remainder` field for that tail without promising it is always an episode title.

Also fixes the consumed-token tracking so repeated values like `S02E02` advance past the episode token, and filters obvious release metadata so normal scene releases do not pick up junk.

fixes #81